### PR TITLE
Probes are sent

### DIFF
--- a/draft-ietf-quic-datagram.md
+++ b/draft-ietf-quic-datagram.md
@@ -248,8 +248,8 @@ packets that only contain DATAGRAM frames, since the timing of these
 acknowledgements is not used for loss recovery.
 
 As with any ack-eliciting frame, when a sender suspects that a packet containing
-only DATAGRAM frames has been lost, it MAY send probe packets to elicit a faster
-acknowledgement as described in Section 6.2.4 of {{!RFC9002}}.
+only DATAGRAM frames has been lost, it sends probe packets to elicit a faster
+acknowledgement as described in {{Section 6.2.4 of RFC9002}}.
 
 If a sender detects that a packet containing a specific DATAGRAM frame might
 have been lost, the implementation MAY notify the application that it believes


### PR DESCRIPTION
RFC 9002 [doesn't
equivocate](https://quicwg.org/base-drafts/rfc9002.html#name-sending-probe-packets)
regarding whether probes are sent:

> When a PTO timer expires, a sender MUST send at least one
ack-eliciting packet in the packet number space as a probe.

This text uses "MAY", which strongly suggests that probes are
discretionary.

That's not true.