### PR TITLE
Cannot rely on transport ACK

### DIFF
--- a/draft-ietf-quic-datagram.md
+++ b/draft-ietf-quic-datagram.md
@@ -256,13 +256,13 @@ have been lost, the implementation MAY notify the application that it believes
 the datagram was lost.
 
 Similarly, if a packet containing a DATAGRAM frame is acknowledged, the
-implementation MAY notify the sender application that the datagram was successfully
-transmitted and received. Due to reordering, this can include a DATAGRAM frame
-that was thought to be lost, but which at a later point was received and
-acknowledged. It is important to note that acknowledgement of a DATAGRAM frame
-only indicates that the transport-layer handling on the receiver processed
-the frame, and does not guarantee that the application on the receiver
-successfully processed the data. Thus, this signal SHOULD NOT replace
+implementation MAY notify the sender application that the datagram was
+successfully transmitted and received. Due to reordering, this can include a
+DATAGRAM frame that was thought to be lost, but which at a later point was
+received and acknowledged. It is important to note that acknowledgement of a
+DATAGRAM frame only indicates that the transport-layer handling on the receiver
+processed the frame, and does not guarantee that the application on the receiver
+successfully processed the data. Thus, this signal cannot replace
 application-layer signals that indicate successful processing.
 
 ## Flow Control


### PR DESCRIPTION
The use of "SHOULD NOT" implies that a) this is discretionary, and b)
that applications might be able to rely on it in some cases.

I don't believe that either is true unless the protocol were specified
entirely differently.  (And that alternative specification wouldn't be
practical anyway.)