### PR TITLE
Include "About this draft" information in the markdown

### DIFF
--- a/.note.xml
+++ b/.note.xml
@@ -1,6 +1,0 @@
-<note title="Discussion Venues" removeInRFC="true">
-<t>Discussion of this document takes place on the QUIC WG mailing list (quic@ietf.org),
-  which is archived at <eref target="https://mailarchive.ietf.org/arch/browse/quic/"/>.</t>
-<t>Source for this draft and an issue tracker can be found at
-  <eref target="https://github.com/quicwg/datagram"/>.</t>
-</note>

--- a/draft-ietf-quic-datagram.md
+++ b/draft-ietf-quic-datagram.md
@@ -5,6 +5,13 @@ docname: draft-ietf-quic-datagram-latest
 date:
 category: std
 wg: QUIC
+venue:
+  group: "QUIC"
+  type: "Working Group"
+  mail: "quic@ietf.org"
+  arch: "https://mailarchive.ietf.org/arch/browse/quic/"
+  github: "quicwg/datagram"
+  latest: "https://quicwg.github.io/datagram/draft-ietf-quic-datagram.html"
 
 ipr: trust200902
 keyword: Internet-Draft


### PR DESCRIPTION
This is a relatively new feature for the kramdown format and it's been tweaked to be nicer.